### PR TITLE
add maintain to possible answers

### DIFF
--- a/dp-game-webapp/app/game/play/adjustVariance.tsx
+++ b/dp-game-webapp/app/game/play/adjustVariance.tsx
@@ -17,14 +17,14 @@ export default function adjustVariance({
     <div className={className}>
       <div className="flex justify-between items-center">
         <button
-          className="h-12 w-32 lg:w-40 bg-slate-400 hover:bg-slate-500 text-white font-bold py-2 px-2 rounded flex items-center justify-between"
+          className="h-12 w-32 md:w-40 bg-slate-400 hover:bg-slate-500 text-white font-bold py-2 px-2 rounded flex items-center justify-between"
           onClick={handleDecreaseButtonClick}
         >
           <ArrowDownCircleIcon className="h-8 w-auto" />
           Decrease Variance
         </button>
         <button
-          className="h-12 w-32 lg:w-40 bg-slate-400 hover:bg-slate-500 text-white font-bold py-2 px-2 rounded flex items-center justify-between"
+          className="h-12 w-32 md:w-40 bg-slate-400 hover:bg-slate-500 text-white font-bold py-2 px-2 rounded flex items-center justify-between"
           onClick={handleIncreaseButtonClick}
         >
           <ArrowUpCircleIcon className="h-8 w-auto" />

--- a/dp-game-webapp/app/game/play/components.tsx
+++ b/dp-game-webapp/app/game/play/components.tsx
@@ -41,13 +41,17 @@ export function GameContainer({ children }: { children: ReactNode }) {
 function Tooltip({
   children,
   tooltipChildren,
+  className,
 }: {
   children: ReactNode;
   tooltipChildren: ReactNode;
+  className: string;
 }) {
   return (
     <div className="relative group">
-      <div className="absolute h-auto bottom-full w-64 md:w-72 py-2 text-sm font-medium text-gray-900 bg-gray-50 border border-gray-200 rounded-lg shadow-sm transition-opacity hover:ease-in group-hover:opacity-100 opacity-0 ease-out duration-150 dark:bg-gray-700 dark:text-white">
+      <div
+        className={`${className} absolute mb-1 h-auto bottom-full py-2 text-sm font-medium text-gray-900 bg-gray-50 border border-gray-200 rounded-lg shadow-sm transition-opacity hover:ease-in group-hover:opacity-100 opacity-0 ease-out duration-150 dark:bg-gray-700 dark:text-white`}
+      >
         {tooltipChildren}
       </div>
       <div className="group">{children}</div>
@@ -55,16 +59,18 @@ function Tooltip({
   );
 }
 
-export function InfoCircleToolTip({
-  className,
-  tooltipChildren,
+export function InfoCircleTooltip({
+  children,
+  tooltipClassName,
+  infoCircleClassName,
 }: {
-  className: string;
-  tooltipChildren: ReactNode;
+  children: ReactNode;
+  tooltipClassName: string;
+  infoCircleClassName: string;
 }) {
   return (
-    <Tooltip tooltipChildren={tooltipChildren}>
-      <InformationCircleIcon className={className} />
+    <Tooltip tooltipChildren={children} className={tooltipClassName}>
+      <InformationCircleIcon className={infoCircleClassName} />
     </Tooltip>
   );
 }

--- a/dp-game-webapp/app/game/play/components.tsx
+++ b/dp-game-webapp/app/game/play/components.tsx
@@ -2,16 +2,12 @@ import { InformationCircleIcon } from "@heroicons/react/24/outline";
 import React, { ReactNode } from "react";
 
 export function PageContainer({ children }: { children: ReactNode }) {
-  return (
-    <div className="mx-auto max-w-7xl px-6 py-32 sm:py-40 lg:px-8">
-      {children}
-    </div>
-  );
+  return <div className="mx-auto max-w-7xl px-6 py-6 md:px-8">{children}</div>;
 }
 
 export function PageTitle({ children }: { children: ReactNode }) {
   return (
-    <h1 className="max-w-2xl text-xl font-bold tracking-tight text-gray-900 sm:text-6xl lg:col-span-2 xl:col-auto">
+    <h1 className="max-w-2xl text-xl font-bold tracking-tight text-gray-900 sm:text-6xl md:col-span-2 xl:col-auto">
       {children}
     </h1>
   );
@@ -19,7 +15,7 @@ export function PageTitle({ children }: { children: ReactNode }) {
 
 export function PageDescription({ children }: { children: ReactNode }) {
   return (
-    <div className="mt-6 max-w-xl lg:mt-0 xl:col-end-1 xl:row-start-1">
+    <div className="mt-6 max-w-xl md:mt-0 xl:col-end-1 xl:row-start-1">
       <p className="text-lg leading-8 text-gray-600">{children}</p>
     </div>
   );
@@ -27,8 +23,8 @@ export function PageDescription({ children }: { children: ReactNode }) {
 
 export function GameContainer({ children }: { children: ReactNode }) {
   return (
-    <div className="sm:mx-auto sm:w-full sm:max-w-[510px]">
-      <div className="max-w-full mt-6 px-2 lg:px-6 py-6 bg-white/60 border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
+    <div className="sm:mx-auto w-full max-w-2xl">
+      <div className="max-w-full mt-6 px-2 md:px-6 py-6 bg-white/60 border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
         {children}
       </div>
     </div>

--- a/dp-game-webapp/app/game/play/page.tsx
+++ b/dp-game-webapp/app/game/play/page.tsx
@@ -6,7 +6,7 @@ import { defaultVariance } from "../simulate";
 import Configure from "./configure";
 import Validate from "./validate";
 import StartGame from "./start";
-import QuestionsGame, { Question } from "./questions";
+import QuestionsGame, { AnsweredQuestion } from "./questions";
 import Results from "./results";
 
 enum GameState {
@@ -34,7 +34,9 @@ export default function Play() {
   const [currentEpsilon, setCurrentEpsilon] = useState<ExponentialNumber>(
     new ExponentialNumber(STARTING_EPSILON_POWER_OF_TEN, 10),
   );
-  const [answeredQuestions, setAnsweredQuestions] = useState<Question[]>([]);
+  const [answeredQuestions, setAnsweredQuestions] = useState<
+    AnsweredQuestion[]
+  >([]);
 
   useEffect(() => {
     setVariance(defaultVariance(conversionRate));

--- a/dp-game-webapp/app/game/play/questions.tsx
+++ b/dp-game-webapp/app/game/play/questions.tsx
@@ -314,24 +314,24 @@ export default function QuestionsGame({
         <div className="flex justify-end items-center">
           {questionPageState === QuestionPageState.Unnoised ? (
             <button
-              className={`mt-10 h-12 w-40 text-white font-bold py-2 px-4 rounded flex items-center justify-between ${
+              className={`mt-10 h-12 w-fit text-white font-bold py-2 px-4 rounded flex items-center justify-between ${
                 allUnnoisedAnswered ? "bg-sky-400 hover:sky-600" : "bg-sky-200"
               }`}
               onClick={handleContinue}
               disabled={!allUnnoisedAnswered}
             >
               Continue to Noised Round{" "}
-              <ArrowRightCircleIcon className="h-8 w-auto" />
+              <ArrowRightCircleIcon className="h-8 w-auto pl-2" />
             </button>
           ) : (
             <button
-              className={`mt-10 h-12 w-40 text-white font-bold py-2 px-4 rounded flex items-center justify-between ${
+              className={`mt-10 h-12 w-fit text-white font-bold py-2 px-4 rounded flex items-center justify-between ${
                 allNoisedAnswered ? "bg-sky-400 hover:sky-600" : "bg-sky-200"
               }`}
               onClick={handleSubmit}
               disabled={!allNoisedAnswered}
             >
-              Submit <ArrowRightCircleIcon className="h-8 w-auto" />
+              Submit <ArrowRightCircleIcon className="h-8 w-auto pl-2" />
             </button>
           )}
         </div>
@@ -362,32 +362,35 @@ function AnswerButtons({
   };
 
   return (
-    <div className="flex justify-between space-x-1 lg:space-x-4">
+    <div className="flex justify-between space-x-1 md:space-x-4">
       <button
-        className={`h-8 lg:h-12 lg:py-2 px-1 lg:px-4 text-base text-sm lg:text-lg font-medium text-white hover:bg-cyan-700 rounded-lg flex items-center justify-between ${
+        className={`h-8 md:h-12 md:py-2 px-1 md:px-4 text-base text-sm md:text-lg font-medium text-white hover:bg-cyan-700 rounded-lg flex items-center justify-between ${
           answer === Answer.DecreaseSpend ? "bg-cyan-700" : "bg-cyan-400"
         }`}
         onClick={() => handleDecreaseSpend(questionIndex)}
       >
-        Decrease <ArrowDownCircleIcon className="h-4 lg:h-8 w-auto ml-2" />
+        <span className="hidden md:flex md:mr-2">Decrease</span>
+        <ArrowDownCircleIcon className="h-6 mx-4 md:mx-0 w-auto" />
       </button>
 
       <button
-        className={`h-8 lg:h-12 lg:py-2 px-1 lg:px-4 text-base text-sm lg:text-lg font-medium text-white hover:bg-teal-700 rounded-lg flex items-center justify-between ${
+        className={`h-8 md:h-12 md:py-2 px-1 md:px-4 text-base text-sm md:text-lg font-medium text-white hover:bg-teal-700 rounded-lg flex items-center justify-between ${
           answer === Answer.MaintainSpend ? "bg-teal-700" : "bg-teal-400"
         }`}
         onClick={() => handleMaintainSpend(questionIndex)}
       >
-        Maintain <MinusCircleIcon className="h-4 lg:h-8 w-autho ml-2" />
+        <span className="hidden md:flex md:mr-2">Maintain</span>
+        <MinusCircleIcon className="h-6 mx-4 md:mx-0 w-auto" />
       </button>
 
       <button
-        className={`h-8 lg:h-12 lg:py-2 px-1 lg:px-4 text-base text-sm lg:text-lg font-medium text-white hover:bg-emerald-700 rounded-lg flex items-center justify-between ${
+        className={`h-8 md:h-12 md:py-2 px-1 md:px-4 text-base text-sm md:text-lg font-medium text-white hover:bg-emerald-700 rounded-lg flex items-center justify-between ${
           answer === Answer.IncreaseSpend ? "bg-emerald-700" : "bg-emerald-400"
         }`}
         onClick={() => handleIncreaseSpend(questionIndex)}
       >
-        Increase <ArrowUpCircleIcon className="h-4 lg:h-8 w-auto ml-2" />
+        <span className="hidden md:flex md:mr-2">Increase</span>
+        <ArrowUpCircleIcon className="h-6 mx-4 md:mx-0 w-auto" />
       </button>
     </div>
   );

--- a/dp-game-webapp/app/game/play/questions.tsx
+++ b/dp-game-webapp/app/game/play/questions.tsx
@@ -14,7 +14,7 @@ import {
 } from "../simulate";
 import { ExponentialNumber } from "../../exponentialNumber";
 import { CampaignStats } from "../campaignStats";
-import { GameContainer, InfoCircleToolTip, PageContainer } from "./components";
+import { GameContainer, InfoCircleTooltip, PageContainer } from "./components";
 
 export enum Answer {
   IncreaseSpend,
@@ -244,10 +244,11 @@ export default function QuestionsGame({
         </div>
 
         <div className="mb-6 flex-col items-center justify-between text-lg font-semibold">
-          For each of these results, would you increase or decrease spend?
+          For each of these results, would you increase, decrease, or maintain
+          spend?
         </div>
 
-        <table className="min-w-full divide-y divide-gray-200">
+        <table className="table-auto min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
               <th
@@ -257,20 +258,20 @@ export default function QuestionsGame({
                 {questionPageState === QuestionPageState.Unnoised ? (
                   <span>Conversions</span>
                 ) : (
-                  <span className="flex items-center">
-                    <span className="mr-2">Conversions</span>
-                    <InfoCircleToolTip
-                      className="h-5 w-auto -mt-1 -mx-1"
-                      tooltipChildren={
-                        <div className="font-light normal-case">
-                          The true observed falls within the provided range 95%
-                          of the time.
-                          <br />
-                          <b>Note:</b> This is not a confidence interval on the
-                          true conversion rate.
-                        </div>
-                      }
-                    />
+                  <span className="flex justify-center items-center">
+                    Conversions
+                    <InfoCircleTooltip
+                      infoCircleClassName="h-5 w-auto -mt-1 mx-1"
+                      tooltipClassName="w-64 -ml-20"
+                    >
+                      <div className="font-light normal-case">
+                        The true observed falls within the provided range 95% of
+                        the time.
+                        <br />
+                        <b>Note:</b> This is not a confidence interval on the
+                        true conversion rate.
+                      </div>
+                    </InfoCircleTooltip>
                   </span>
                 )}
               </th>
@@ -278,7 +279,29 @@ export default function QuestionsGame({
                 scope="col"
                 className="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
               >
-                Increase/Decrease Spend?
+                <span className="flex justify-center items-center">
+                  Decision
+                  <InfoCircleTooltip
+                    infoCircleClassName="h-5 w-auto -mt-1 mx-1"
+                    tooltipClassName="w-64 -ml-40 md:-ml-32"
+                  >
+                    <div className="font-light normal-case">
+                      Possible decisions:
+                      <div className="flex justify-start items-center">
+                        <ArrowDownCircleIcon className="h-6 mx-4 w-auto" />
+                        <span>Decrease</span>
+                      </div>
+                      <div className="flex justify-start items-center">
+                        <MinusCircleIcon className="h-6 mx-4 w-auto" />
+                        <span>Maintain</span>
+                      </div>
+                      <div className="flex justify-start items-center">
+                        <ArrowUpCircleIcon className="h-6 mx-4 w-auto" />
+                        <span>Increase</span>
+                      </div>
+                    </div>
+                  </InfoCircleTooltip>
+                </span>
               </th>
             </tr>
           </thead>

--- a/dp-game-webapp/app/game/play/results.tsx
+++ b/dp-game-webapp/app/game/play/results.tsx
@@ -1,13 +1,27 @@
-import React from "react";
+import React, { ReactNode } from "react";
 
 import {
   ArrowUpCircleIcon,
   ArrowDownCircleIcon,
+  MinusCircleIcon,
 } from "@heroicons/react/24/outline";
 
-import { Question } from "./questions";
+import { Answer, AnsweredQuestion } from "./questions";
 import { ExponentialNumber } from "../../exponentialNumber";
 import { GameContainer, PageContainer, PageTitle } from "./components";
+
+const answerIcons: Record<Answer, ReactNode> = {
+  [Answer.DecreaseSpend]: (
+    <ArrowDownCircleIcon className="h-4 lg:h-8 w-auto ml-2" />
+  ),
+  [Answer.MaintainSpend]: (
+    <MinusCircleIcon className="h-4 lg:h-8 w-autho ml-2" />
+  ),
+
+  [Answer.IncreaseSpend]: (
+    <ArrowUpCircleIcon className="h-4 lg:h-8 w-auto ml-2" />
+  ),
+};
 
 export default function Results({
   answeredQuestions,
@@ -18,7 +32,7 @@ export default function Results({
   setGameStatePlaying,
   setGameStateConfigure,
 }: {
-  answeredQuestions: Question[];
+  answeredQuestions: AnsweredQuestion[];
   num_questions: number;
   currentEpsilon: ExponentialNumber;
   nextEpsilon: ExponentialNumber;
@@ -28,7 +42,7 @@ export default function Results({
 }) {
   const numCorrect = answeredQuestions.reduce(
     (count, question) =>
-      question.unnoisedResult === question.noisedResult ? count + 1 : count,
+      question.unnoisedAnswer === question.noisedAnswer ? count + 1 : count,
     0,
   );
 
@@ -85,7 +99,7 @@ export default function Results({
                 <tr
                   key={index}
                   className={
-                    item.unnoisedResult == item.noisedResult
+                    item.unnoisedAnswer == item.noisedAnswer
                       ? "bg-emerald-50 hover:bg-emerald-200"
                       : "bg-rose-50 hover:bg-rose-200"
                   }
@@ -94,11 +108,7 @@ export default function Results({
                     {item.conversions.toLocaleString()}
                   </td>
                   <td className="px-1 py-4 text-center whitespace-nowrap text-sm font-medium text-gray-700">
-                    {item.unnoisedResult ? (
-                      <ArrowDownCircleIcon className="h-8 w-auto" />
-                    ) : (
-                      <ArrowUpCircleIcon className="h-8 w-auto" />
-                    )}
+                    {answerIcons[item.unnoisedAnswer]}
                   </td>
                   <td className="px-1 py-4 text-center whitespace-nowrap text-sm font-medium text-gray-700">
                     {(
@@ -106,11 +116,7 @@ export default function Results({
                     ).toLocaleString()}
                   </td>
                   <td className="px-1 py-4 text-center whitespace-nowrap text-sm font-medium text-gray-700">
-                    {item.noisedResult ? (
-                      <ArrowDownCircleIcon className="h-8 w-auto" />
-                    ) : (
-                      <ArrowUpCircleIcon className="h-8 w-auto" />
-                    )}
+                    {answerIcons[item.noisedAnswer]}
                   </td>
                 </tr>
               ))}

--- a/dp-game-webapp/app/game/play/results.tsx
+++ b/dp-game-webapp/app/game/play/results.tsx
@@ -12,14 +12,14 @@ import { GameContainer, PageContainer, PageTitle } from "./components";
 
 const answerIcons: Record<Answer, ReactNode> = {
   [Answer.DecreaseSpend]: (
-    <ArrowDownCircleIcon className="h-4 lg:h-8 w-auto ml-2" />
+    <ArrowDownCircleIcon className="h-4 md:h-8 w-auto ml-2" />
   ),
   [Answer.MaintainSpend]: (
-    <MinusCircleIcon className="h-4 lg:h-8 w-autho ml-2" />
+    <MinusCircleIcon className="h-4 md:h-8 w-autho ml-2" />
   ),
 
   [Answer.IncreaseSpend]: (
-    <ArrowUpCircleIcon className="h-4 lg:h-8 w-auto ml-2" />
+    <ArrowUpCircleIcon className="h-4 md:h-8 w-auto ml-2" />
   ),
 };
 

--- a/dp-game-webapp/app/game/play/start.tsx
+++ b/dp-game-webapp/app/game/play/start.tsx
@@ -41,7 +41,7 @@ export default function StartGame({
 
         <div className="flex justify-between items-center mt-10 space-x-4">
           <button
-            className="mt-10 h-12 w-32 lg:w-40 bg-red-400 hover:bg-red-600 text-white font-bold py-2 px-4 rounded flex items-center justify-between"
+            className="mt-10 h-12 w-32 md:w-40 bg-red-400 hover:bg-red-600 text-white font-bold py-2 px-4 rounded flex items-center justify-between"
             onClick={setGameStateValidate}
           >
             <ArrowLeftCircleIcon className="h-8 w-auto" />
@@ -49,7 +49,7 @@ export default function StartGame({
           </button>
 
           <button
-            className="mt-10 h-12 w-32 lg:w-40 bg-sky-400 hover:bg-sky-600 text-white font-bold py-2 px-4 rounded flex items-center justify-between"
+            className="mt-10 h-12 w-32 md:w-40 bg-sky-400 hover:bg-sky-600 text-white font-bold py-2 px-4 rounded flex items-center justify-between"
             onClick={setGameStatePlaying}
           >
             Start <ArrowRightCircleIcon className="h-8 w-auto" />

--- a/dp-game-webapp/app/game/play/validate.tsx
+++ b/dp-game-webapp/app/game/play/validate.tsx
@@ -241,14 +241,14 @@ function Navigation({
     <div className={className}>
       <div className="flex justify-between items-center">
         <button
-          className="h-12 w-32 lg:w-40 bg-red-400 hover:bg-red-600 text-white font-bold py-2 px-4 rounded flex items-center justify-between"
+          className="h-12 w-32 md:w-40 bg-red-400 hover:bg-red-600 text-white font-bold py-2 px-4 rounded flex items-center justify-between"
           onClick={setGameStateConfigure}
         >
           <ArrowLeftCircleIcon className="h-8 w-auto" />
           Back
         </button>
         <button
-          className="h-12 w-32 lg:w-40 bg-sky-400 hover:bg-sky-600 text-white font-bold py-2 px-4 rounded flex items-center justify-between"
+          className="h-12 w-32 md:w-40 bg-sky-400 hover:bg-sky-600 text-white font-bold py-2 px-4 rounded flex items-center justify-between"
           onClick={setGameStateStart}
         >
           Continue <ArrowRightCircleIcon className="h-8 w-auto" />

--- a/dp-game-webapp/app/layout.tsx
+++ b/dp-game-webapp/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
             {/* Hero section */}
             <div className="relative isolate -z-10 overflow-hidden bg-gradient-to-b min-h-screen from-indigo-100/20 pt-14">
               <div
-                className="absolute inset-y-0 right-1/2 -z-10 -mr-96 w-[200%] origin-top-right skew-x-[-30deg] bg-white shadow-xl shadow-indigo-600/10 ring-1 ring-indigo-50 sm:-mr-80 lg:-mr-96"
+                className="absolute inset-y-0 right-1/2 -z-10 -mr-96 w-[200%] origin-top-right skew-x-[-30deg] bg-white shadow-xl shadow-indigo-600/10 ring-1 ring-indigo-50 sm:-mr-80 md:-mr-96"
                 aria-hidden="true"
               />
 

--- a/dp-game-webapp/app/nav.tsx
+++ b/dp-game-webapp/app/nav.tsx
@@ -19,16 +19,16 @@ export default function Header() {
   return (
     <header className="absolute inset-x-0 top-0 z-50">
       <nav
-        className="mx-auto flex max-w-7xl items-center justify-between p-6 lg:px-8"
+        className="mx-auto flex max-w-7xl items-center justify-between p-6 md:px-8"
         aria-label="Global"
       >
-        <div className="flex lg:flex-1">
+        <div className="flex md:flex-1">
           <Link href="/" className="-m-1.5 p-1.5">
             <span className="sr-only">Differential Privacy Game</span>
             <PuzzlePieceIcon className="h-8 w-auto" />
           </Link>
         </div>
-        <div className="flex lg:hidden">
+        <div className="flex md:hidden">
           <button
             type="button"
             className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700"
@@ -38,7 +38,7 @@ export default function Header() {
             <Bars3Icon className="h-6 w-6" aria-hidden="true" />
           </button>
         </div>
-        <div className="hidden lg:flex lg:gap-x-12">
+        <div className="hidden md:flex md:gap-x-12">
           {navigation.map((item) => (
             <a
               key={item.name}
@@ -49,7 +49,7 @@ export default function Header() {
             </a>
           ))}
         </div>
-        <div className="hidden lg:flex lg:flex-1 lg:justify-end">
+        <div className="hidden md:flex md:flex-1 md:justify-end">
           {/* Commenting out until we add login functionality. */}
           {/*   <a href="#" className="text-sm font-semibold leading-6 text-gray-900"> */}
           {/*     Log in <span aria-hidden="true">&rarr;</span> */}
@@ -58,7 +58,7 @@ export default function Header() {
       </nav>
       <Dialog
         as="div"
-        className="lg:hidden"
+        className="md:hidden"
         open={mobileMenuOpen}
         onClose={setMobileMenuOpen}
       >

--- a/dp-game-webapp/app/page.tsx
+++ b/dp-game-webapp/app/page.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import Link from "next/link";
 
-export default function Example() {
+export default function Index() {
   return (
     <>
-      <div className="lg:flex lg:flex-1 lg:justify-center max-w-10xl px-6 py-12 lg:py-20 lg:px-8 lg:space-x-8">
-        <h1 className="max-w-xl text-xl font-bold tracking-tight text-gray-900 lg:text-6xl lg:col-span-2 xl:col-auto">
+      <div className="md:flex md:flex-1 md:justify-center max-w-10xl px-6 py-6 md:py-40 md:px-8 md:space-x-8">
+        <h1 className="max-w-xl text-xl font-bold tracking-tight text-gray-900 md:text-6xl md:col-span-2 xl:col-auto">
           Welcome to the Differential Privacy Game!
         </h1>
         <br />
-        <div className="mt-6 max-w-xl lg:mt-0 xl:col-end-1 xl:row-start-1">
+        <div className="mt-6 max-w-xl md:mt-0 xl:col-end-1 xl:row-start-1">
           <p className="text-lg leading-8 text-gray-600">
             This game is designed to demonstrate the effect of decision making
             for advertising professionals with differentially private results.


### PR DESCRIPTION
(currently stacked on #32. needs to be based on main after #32 is merged.)

this is in progress. it adds the maintain button and functionality, but doesn't look great. 

for larger screens, we can probably just make the `GameContainer` wider, but for smaller screens we may want to put the conversion count and the buttons on different rows. open to suggestions!